### PR TITLE
Add output history tracking

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -6,7 +6,7 @@
 
     'description': """
 Cotizacion por porcentaje, ajuste en los productos campos de cliente y usuario administrador
-modificacion de los porductos para los filtros de entradas no cotizadas, y filtros de entradas por cliente
+modificacion de los productos para los filtros de entradas no cotizadas, y filtros de entradas por cliente
     """,
 
     'author': "Daniel Olivares",
@@ -23,7 +23,7 @@ modificacion de los porductos para los filtros de entradas no cotizadas, y filtr
 
     # always loadeds
     'data': [
-        # 'security/ir.model.access.csv',
+        'security/ir.model.access.csv',
         'views/views.xml',
         'views/templates.xml',
         'views/report_by_date_template.xml',

--- a/security/ir.model.access.csv
+++ b/security/ir.model.access.csv
@@ -1,2 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_product_client_product_client,product_client.product_client,model_product_client_product_client,base.group_user,1,1,1,1
+access_product_output_history,product.output.history,model_product_output_history,base.group_user,1,0,0,0

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_sale_order_line

--- a/tests/test_sale_order_line.py
+++ b/tests/test_sale_order_line.py
@@ -1,0 +1,24 @@
+from odoo.tests.common import TransactionCase
+from odoo import exceptions
+
+class TestSaleOrderLine(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.partner = self.env['res.partner'].create({'name': 'Test Partner'})
+        self.product_tmpl = self.env['product.template'].create({
+            'name': 'Test Product',
+            'detailed_type': 'product',
+            'list_price': 10.0,
+            'standard_price': 5.0,
+            'is_quoted': True,
+        })
+        self.product = self.product_tmpl.product_variant_id
+        self.sale_order = self.env['sale.order'].create({'partner_id': self.partner.id})
+
+    def test_create_line_with_quoted_product_raises(self):
+        with self.assertRaises(exceptions.UserError):
+            self.env['sale.order.line'].create({
+                'order_id': self.sale_order.id,
+                'product_id': self.product.id,
+            })
+

--- a/views/views.xml
+++ b/views/views.xml
@@ -25,8 +25,18 @@
             <xpath expr="//field[@name='uom_id']" position="attributes">
                 <attribute name="groups">base.group_system</attribute>
             </xpath>
+            <xpath expr="//sheet" position="inside">
+                <page string="Historial de Salidas">
+                    <field name="output_history_ids" nolabel="1">
+                        <tree editable="bottom">
+                            <field name="output_number"/>
+                            <field name="changed_at"/>
+                        </tree>
+                    </field>
+                </page>
+            </xpath>
         </field>
- </record>
+</record>
 
 
 <record id="product_product_search_inherit" model="ir.ui.view">
@@ -87,6 +97,7 @@
                     <filter string="Mis entradas listas para entregar" name="my_products_ready" domain="[('related_agent_id','=',uid),('is_ready_for_bill','=',True),('is_finished','=',False)]"/>
                     <filter string="Mis entradas Finalizadas" name="my_products_is_finished" domain="[('related_agent_id','=',uid),('is_finished','=',True)]"/>
                     <filter string="Mis entradas Revisadas" name="my_products_reviewed" domain="[('related_agent_id','=',uid),('reviewed','=',True)]"/>
+                    <filter string="Con historial de salidas" name="has_output_history" domain="[('output_history_ids','!=',False)]"/>
                      <!-- tipos de operaciones -->
                      <separator string="Tipos de Operaciones (No Finalizadas)" />
                     <filter string="Auto Declaracion" name="t_auto" domain="[('t_operacion','=','01'),('is_finished','=',False),('related_agent_id','=',uid)]"/>
@@ -165,7 +176,7 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='product_template_id']" position="attributes">
                 <attribute name="domain">[('detailed_type', '=', 'service')]</attribute>
-                <attribute name='options'>{'no_create': True}</attribute>"
+                <attribute name='options'>{'no_create': True}</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
## Summary
- fix typo in module manifest and load access rights
- allow managing output history for products
- add filter and view section for output history
- provide read access for output history model
- add regression test for sale order line creation with quoted product

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f5faa9ca88326a94f7fd1df3f9fa8